### PR TITLE
DOPS-5632: modify script and dockerfile to support arm64 and amd64 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 php-fpm-exporter.darwin.amd64
 php-fpm-exporter.linux.amd64
 *.sha256.txt
+php-fpm-exporter.darwin.arm64
+php-fpm-exporter.linux.arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM       golang:alpine as builder
+ARG ARCH=amd64
+FROM --platform=linux/${ARCH} golang:1.22-alpine AS builder
 
 RUN apk --no-cache add bash make openssl
-COPY . /go/src/github.com/bakins/php-fpm-exporter
-RUN cd /go/src/github.com/bakins/php-fpm-exporter && ./script/build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -o /php-fpm-exporter ./cmd/php-fpm-exporter
 
-FROM scratch
-COPY --from=builder /go/src/github.com/bakins/php-fpm-exporter/php-fpm-exporter.linux.amd64 /php-fpm-exporter
+FROM --platform=linux/${ARCH} alpine:3.19
+COPY --from=builder /php-fpm-exporter /php-fpm-exporter
 
-ENTRYPOINT [ "/php-fpm-exporter" ]
+ENTRYPOINT ["/php-fpm-exporter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-ARG ARCH=amd64
-FROM --platform=linux/${ARCH} golang:1.22-alpine AS builder
+# Multi-arch Dockerfile for php-fpm-exporter
+# Build with Buildx for linux/amd64 and linux/arm64
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
+
+ARG TARGETPLATFORM
+ARG TARGETARCH
 
 RUN apk --no-cache add bash make openssl
 WORKDIR /src
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -o /php-fpm-exporter ./cmd/php-fpm-exporter
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /php-fpm-exporter ./cmd/php-fpm-exporter
 
-FROM --platform=linux/${ARCH} alpine:3.19
+FROM scratch
 COPY --from=builder /php-fpm-exporter /php-fpm-exporter
 
 ENTRYPOINT ["/php-fpm-exporter"]

--- a/exporter.go
+++ b/exporter.go
@@ -137,7 +137,10 @@ func (e *Exporter) Run() error {
 	if err := prometheus.Register(c); err != nil {
 		return errors.Wrap(err, "failed to register metrics")
 	}
-	prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	prometheus.Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{
+		PidFn: func() (int, error) { return os.Getpid(), nil },
+		Namespace: "",
+	}))
 	prometheus.Unregister(prometheus.NewGoCollector())
 
 	http.HandleFunc("/healthz", e.healthz)

--- a/script/build
+++ b/script/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 NAME=php-fpm-exporter
-ARCH=amd64
+ARCH=${1:-amd64}
 
 export GOFLAGS=-mod=vendor
 export GO111MODULE=on
@@ -9,6 +9,6 @@ export GO111MODULE=on
 for OS in darwin linux; do
     FILE=${NAME}.${OS}.${ARCH}
     CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -o ${FILE} ./cmd/${NAME}
-    SHA=`openssl sha256 ${FILE} | awk '{print $2}'`
+    SHA=$(openssl sha256 ${FILE} | awk '{print $2}')
     echo "${SHA} ${FILE}" > ${FILE}.sha256.txt
 done


### PR DESCRIPTION
## Jira
DOPS-5632


## Description
This pull request introduces improvements to the build process, Dockerfile configuration, and Prometheus collector registration. The most important changes include making the build process architecture-agnostic, enhancing Dockerfile flexibility, and updating Prometheus collector usage for better customization.

### Build process improvements:
* [`script/build`](diffhunk://#diff-99b83631df533ea1d9c97396a043a4670464f523d0c1e60b0a1cab6dddd440f9L4-R12): Modified the script to accept an optional architecture argument (`ARCH`) instead of hardcoding it to `amd64`. This change allows building for different architectures dynamically.

### Dockerfile updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R10): Updated the base image to support multi-architecture builds by introducing the `ARCH` argument and `--platform` flag. Simplified the build process by using a single `WORKDIR` and adjusted the build command to dynamically set the target architecture.

### Prometheus collector enhancements:
* [`exporter.go`](diffhunk://#diff-e4987a222ab3e846614998485952d8ee42288062a30929290cf3ea0e815d5ae1L140-R143): Replaced the deprecated `prometheus.NewProcessCollector` call with a new version that uses `ProcessCollectorOpts` for better configuration flexibility.


## How I've tested my work ?
<!-- You can add explications, test results and/or screenshots. -->

